### PR TITLE
Hardcode http in the url constructors

### DIFF
--- a/client.go
+++ b/client.go
@@ -97,7 +97,6 @@ func (c *Client) doRequst(method, url string)(int, string, *http.Response, error
 		request.Header.Add("Content-Type", "application/json")
 		var content string
 		if response, err := client.Do(request); err != nil {
-            log.Println("HERE")
             log.Printf("Unable to make call to Mesos: %s", err)
             c.logger.Printf("Unable to make call to Mesos: %s", err)
             return 0, "", nil, errors.New("Unable to make call to Mesos")
@@ -142,5 +141,5 @@ func (c *Client) slaveStatsURL(hostname string) string {
 }
 
 func (c *Client) slaveURL(hostname, uri string) string {
-    return fmt.Sprintf("%s//%s:%d/%s", c.config.getScheme(), hostname, c.config.SlavePort, uri)
+    return fmt.Sprintf("http://%s:%d/%s", hostname, c.config.SlavePort, uri)
 }

--- a/client.go
+++ b/client.go
@@ -122,7 +122,7 @@ func (c *Client) buildDiscoveryURL(uri string) string {
 
 
 func (c *Client) setMasterURL(leader string) {
-    c.config.MasterURL = fmt.Sprintf("%s//%s:%d", c.config.getScheme(), leader, c.config.MasterPort)
+    c.config.MasterURL = fmt.Sprintf("http://%s:%d", leader, c.config.MasterPort)
 }
 
 

--- a/cluster.go
+++ b/cluster.go
@@ -43,8 +43,8 @@ func (c *Cluster) getLeader() (string) {
 func (c *Cluster) LoadSlaveStates(client MesosClient) (error) {
     var erred bool
 
-    for i := range c.Slaves {
-        if err := c.Slaves[i].LoadState(client); err != nil {
+    for _, s := range c.Slaves {
+        if err := s.LoadState(client); err != nil {
             erred = true
         }
     }
@@ -56,8 +56,8 @@ func (c *Cluster) LoadSlaveStates(client MesosClient) (error) {
 func (c *Cluster) LoadSlaveStats(client MesosClient) (error) {
     var erred bool
 
-    for i := range c.Slaves {
-        if err := c.Slaves[i].LoadStats(client); err != nil {
+    for _, s := range c.Slaves {
+        if err := s.LoadStats(client); err != nil {
             erred = true
         }
     }


### PR DESCRIPTION
Since the current use case is entirely http, the additional complexity isn't needed and actually makes a few edge cases more difficult when implementing other tools using this library.

Also cleans up loop syntax and removes a debugging log line.
